### PR TITLE
Change dependency from `matplotlib` to `matplotlib-base`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @MarieS-WiMLDS @augustebaum @glemaitre @sylvaincom @thomass-dev @tuscland
+* @MarieSacksick @auguste-probabl @glemaitre @sylvaincom @thomass-dev @tuscland

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@MarieS-WiMLDS](https://github.com/MarieS-WiMLDS/)
-* [@augustebaum](https://github.com/augustebaum/)
+* [@MarieSacksick](https://github.com/MarieSacksick/)
+* [@auguste-probabl](https://github.com/auguste-probabl/)
 * [@glemaitre](https://github.com/glemaitre/)
 * [@sylvaincom](https://github.com/sylvaincom/)
 * [@thomass-dev](https://github.com/thomass-dev/)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
     - skore = skore.__main__:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -26,7 +26,7 @@ requirements:
     - diskcache
     - fastapi
     - joblib
-    - matplotlib
+    - matplotlib-base
     - numpy
     - pandas
     - plotly >=5,<6


### PR DESCRIPTION
As suggested by the bot

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* ~[ ] Reset the build number to `0` (if the version changed)~
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
