### PR TITLE
skore v0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,11 +10,9 @@ source:
   sha256: ea83a9fa2702e956c78e7ab3bea09ad4ed2c63b024cf81ba93c788727c1ce00b
 
 build:
-  entry_points:
-    - skore = skore.__main__:main
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 1
+  number: 0
 
 requirements:
   host:
@@ -40,7 +38,6 @@ test:
     - skore
   commands:
     - pip check
-    - skore --help
   requires:
     - python {{ python_min }}
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "skore" %}
-{% set version = "0.7.1" %}
+{% set version = "0.8.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/skore-{{ version }}.tar.gz
-  sha256: 28a34803660f22802cdb2717d449a84483c9e758af1a30e2764b6fef2c9bfaae
+  sha256: ea83a9fa2702e956c78e7ab3bea09ad4ed2c63b024cf81ba93c788727c1ce00b
 
 build:
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,25 +22,18 @@ requirements:
     - hatchling
     - pip
   run:
-    - python >={{ python_min }}
     - diskcache
-    - fastapi
     - joblib
     - matplotlib-base
     - numpy
-    - orjson
     - pandas
-    - platformdirs
-    - plotly >=5,<6
-    - psutil
-    - pyarrow
+    - python >={{ python_min }}
     - rich
     - scikit-learn
+    - skops
     # Need to pin sqlite for compatibility reason with diskcache
     # cf. https://github.com/probabl-ai/skore/issues/1353
     - sqlite <3.49
-    - skops
-    - uvicorn
 
 test:
   imports:


### PR DESCRIPTION
skore v0.8 does not expose a CLI; the recipe was updated to reflect this.
